### PR TITLE
Local nodemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can use this starter kit to efficiently develop react components and applica
 
 ### Dependencies
 
-* You need node.js v4+ and nodemon v1.6+ installed globally on your machine. If using OS X, best to install node using [Homebrew](http://brew.sh/). Node v0.12 might work too, but I don't test it anymore.
+* You need node.js v4+ installed globally on your machine. If using OS X, best to install node using [Homebrew](http://brew.sh/). Node v0.12 might work too, but I don't test it anymore.
 * npm `devDependencies` are required to develop on and build the project.
 * npm `dependencies` are the only ones that are required to run the app in production once it has been built.
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "start": "NODE_ENV=production     node --harmony src/server.js",
     "build": "NODE_ENV=production     node --harmony src/scripts/make.js  &&  NODE_ENV=production   webpack -p --config src/config/webpack-config.js",
     "webpack": "NODE_ENV=development  node --harmony src/scripts/make.js  &&  NODE_ENV=development  node --harmony src/webpack-dev-server.js",
-    "dev": "NODE_ENV=development      node --harmony src/scripts/make.js  &&  NODE_ENV=development  nodemon --harmony src/server.js",
+    "dev": "NODE_ENV=development      node --harmony src/scripts/make.js  &&  NODE_ENV=development  ./node_modules/nodemon/bin/nodemon.js --harmony src/server.js",
     "make": "NODE_ENV=development     node --harmony src/scripts/make.js",
     "lint": "eslint . --ext .js --ext .jsx"
   },
@@ -47,6 +47,7 @@
     "eslint-plugin-react": "^3.2.2",
     "express": "^4.13.3",
     "h2o2": "^4.0.1",
+    "nodemon": "^1.8.1",
     "react-hot-loader": "^1.2.8",
     "react-transform-hmr": "^1.0.1",
     "style-loader": "^0.12.3",


### PR DESCRIPTION
This eliminates the global `nodemon` dependency. It adds `nodemon` to `devDependencies` in `package.json`. It also modifies the `npm run dev` script so that the locally installed package is used instead. 

cc @raquo 
