### PR TITLE
Local IP

### DIFF
--- a/src/config/variables.js
+++ b/src/config/variables.js
@@ -55,7 +55,7 @@ var config = {
 if (process.env.NODE_ENV === 'development') {
     deepExtend(config, {
         server: {
-            host: 'localhost',
+            host: '0.0.0.0',
             port: 3000,
             protocol: 'http'
         },


### PR DESCRIPTION
This changes the config for `host` when `NODE_ENV === 'development'` to `0.0.0.0`. I did so to allow `HMR` goodness to occur on externally connected clients. It's especially helpful for developing mobile web.
