### PR TITLE
Gitignore c9 settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 *.iml
 .idea/*
+.c9/*
 
 # Generated files:
 nodemon.json


### PR DESCRIPTION
This adds to `.gitignore` an entry to ignore `c9` editor settings, similar to the `.idea/*` entry.
