### PR TITLE
make deployable to heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,26 +17,21 @@
     "url": "https://github.com/raquo/minimal-hapi-react-webpack"
   },
   "main": "src/server.js",
+  "engines": {
+    "node": "^4.2.2"
+  },
   "scripts": {
     "start": "NODE_ENV=production     node --harmony src/server.js",
     "build": "NODE_ENV=production     node --harmony src/scripts/make.js  &&  NODE_ENV=production   webpack -p --config src/config/webpack-config.js",
     "webpack": "NODE_ENV=development  node --harmony src/scripts/make.js  &&  NODE_ENV=development  node --harmony src/webpack-dev-server.js",
     "dev": "NODE_ENV=development      node --harmony src/scripts/make.js  &&  NODE_ENV=development  ./node_modules/nodemon/bin/nodemon.js --harmony src/server.js",
     "make": "NODE_ENV=development     node --harmony src/scripts/make.js",
-    "lint": "eslint . --ext .js --ext .jsx"
+    "lint": "eslint . --ext .js --ext .jsx",
+    "postinstall": "npm run build"
   },
   "dependencies": {
-    "chalk": "^1.1.1",
-    "hapi": "^11.1.2",
-    "hapi-react-views": "^5.0.1",
-    "inert": "^3.2.0",
-    "react": "^0.14.3",
-    "react-dom": "^0.14.3",
-    "rimraf": "^2.4.4",
-    "vision": "^4.0.1"
-  },
-  "devDependencies": {
     "assets-webpack-plugin": "^3.2.0",
+    "css-loader": "^0.23.0",
     "babel-core": "^6.3.17",
     "babel-eslint": "^4.1.6",
     "babel-loader": "^6.2.0",
@@ -45,17 +40,26 @@
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-1": "^6.3.13",
     "babel-register": "^6.3.13",
-    "css-loader": "^0.23.0",
+    "chalk": "^1.1.1",
+    "hapi": "^11.1.2",
+    "hapi-react-views": "^5.0.1",
+    "inert": "^3.2.0",
+    "react": "^0.14.3",
+    "react-dom": "^0.14.3",
+    "rimraf": "^2.4.4",
+    "style-loader": "^0.13.0",
+    "vision": "^4.0.1",
+    "webpack": "^1.11.0",
+    "webpack-dev-middleware": "^1.2.0",
+    "webpack-hot-middleware": "^2.3.0"
+  },
+  "devDependencies": {
     "eslint": "^1.1.0",
     "eslint-loader": "^1.0.0",
     "eslint-plugin-react": "^3.2.2",
     "express": "^4.13.3",
     "h2o2": "^4.0.1",
     "nodemon": "^1.8.1",
-    "react-transform-hmr": "^1.0.1",
-    "style-loader": "^0.13.0",
-    "webpack": "^1.11.0",
-    "webpack-dev-middleware": "^1.2.0",
-    "webpack-hot-middleware": "^2.3.0"
+    "react-transform-hmr": "^1.0.1"
   }
 }

--- a/src/config/variables.js
+++ b/src/config/variables.js
@@ -18,11 +18,11 @@ var WEBPACK_DEV_SERVER_PORT = 3001;
 
 if (process.env.NODE_ENV === 'development') {
     SERVER_HOST = '0.0.0.0';
-    SERVER_PORT = 3000;
+    SERVER_PORT = process.env.PORT || 3000;
 
 } else if (process.env.NODE_ENV === 'production') {
-    SERVER_HOST = 'localhost';
-    SERVER_PORT = 2000;
+    SERVER_HOST = '0.0.0.0';
+    SERVER_PORT = process.env.PORT || 2000;
 
 } else {
     var errorText = '[' + path.basename(__filename) + '] ERROR: NODE_ENV is not set: ' + process.env.NODE_ENV;


### PR DESCRIPTION
This makes the app deployable to heroku:
https://minimal-hapi-react-webpack.herokuapp.com/

just needed some config:
- [x] be specific with the `node` version for heroku to use
- [x] a `postinstall` hook (script) to `npm run build` on heroku after `npm install` finishes
- [x] move the `dependencies` heroku needs to `npm run build` to `devDependencies`
- [x] heroku specifies port via `process.env.PORT`; account for that in `variables.js`
- [x] use `0.0.0.0` instead of `localhost` for `process.env.NODE_ENV === 'production'`; same as `development`
