### PR TITLE
upgrade to webpack 2

### DIFF
--- a/src/config/webpack-config.js
+++ b/src/config/webpack-config.js
@@ -8,10 +8,10 @@ const config = require('./variables');
 const APP_ENTRY = path.join(config.paths.source, 'main-app');
 const WEBPACK_HOT_ENTRY = `webpack-hot-middleware/client?path=${config.webpack.devServerUrl}/__webpack_hmr`;
 const JS_JSX = /\.(js|jsx)$/; // We allow both .js or .jsx extensions for JS code – choose what you like more.
-const BABEL = 'babel'; // We use Babel to transpile ES6/JSX into ES5. See .babelrc file for additional rules.
+const BABEL = 'babel-loader'; // We use Babel to transpile ES6/JSX into ES5. See .babelrc file for additional rules.
 const CSS_LOADER = {
   test: /\.css$/,
-  loaders: ['style', 'css'], // Loaders are processed last-to-first
+  use: ['style-loader', 'css-loader'], // Loaders are processed last-to-first
   include: config.paths.source
 };
 
@@ -20,7 +20,7 @@ const webpackConfig = {
   resolve: {
     // Webpack tries to append these extensions when you require(moduleName)
     // The empty extension allows specifying the extension in a require call, e.g. require('./main-app.css')
-    extensions: ['', '.js', '.jsx']
+    extensions: ['.js', '.jsx']
   },
   output: {
     publicPath: config.publicPaths.build, // Expose bundles in this web directory (only dev server uses this option)
@@ -29,7 +29,6 @@ const webpackConfig = {
   },
   plugins: [
     // new SlowWebpackPlugin({delay: 2000}),
-    new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.DefinePlugin({
       'process.env': {
         NODE_ENV: JSON.stringify(process.env.NODE_ENV)
@@ -52,42 +51,44 @@ if (process.env.NODE_ENV === 'development') {
     },
     devtool: 'cheap-module-eval-source-map', // Generate source maps (more or less efficiently)
     module: {
-      preLoaders: [
+      rules: [
         {
           test: JS_JSX,
-          loader: 'eslint-loader', // Lint all JS files before compiling the bundles (see .eslintrc for rules)
-          include: config.paths.source
-        }
-      ],
-      loaders: [
+          use: {
+            loader: 'eslint-loader', // Lint all JS files before compiling the bundles (see .eslintrc for rules)
+            options: {
+              failOnError: true
+            }
+          },
+          include: config.paths.source,
+          enforce: 'pre'
+        },
         CSS_LOADER,
         {
           test: JS_JSX,
-          loader: BABEL,
-          include: config.paths.source,
-          query: {
-            plugins: [
-              ['react-transform', {
-                transforms: [{
-                  transform: 'react-transform-hmr',
-                  imports: ['react'],
-                  locals: ['module']
+          use: {
+            loader: BABEL,
+            options: {
+              plugins: [
+                ['react-transform', {
+                  transforms: [{
+                    transform: 'react-transform-hmr',
+                    imports: ['react'],
+                    locals: ['module']
+                  }]
                 }]
-              }]
-            ]
-          }
+              ]
+            }
+          },
+          include: config.paths.source
         }
       ]
-    },
-    eslint: {
-      // failOnWarning: true,
-      failOnError: true
     }
   });
 
   Array.prototype.push.apply(webpackConfig.plugins, [
     new webpack.HotModuleReplacementPlugin(), // Enables HMR. Adds webpack/hot/dev-server entry point if hot=true
-    new webpack.NoErrorsPlugin() // @TODO do we really want / need this? On dev or on production too?
+    new webpack.NoEmitOnErrorsPlugin() // @TODO do we really want / need this? On dev or on production too?
   ]);
 } else { // production
   /** @lends webpackConfig */  // this comment is not critical, it just helps some IDEs with autocompletion
@@ -97,7 +98,7 @@ if (process.env.NODE_ENV === 'development') {
     },
     devtool: 'source-map', // generate full source maps
     module: {
-      loaders: [
+      rules: [
         CSS_LOADER,
         {
           test: JS_JSX,
@@ -110,7 +111,8 @@ if (process.env.NODE_ENV === 'development') {
 
   Array.prototype.push.apply(webpackConfig.plugins, [
     new webpack.optimize.UglifyJsPlugin({
-      compressor: {
+      sourceMap: true,
+      compress: {
         warnings: false // Don't complain about things like removing unreachable code
       }
     })


### PR DESCRIPTION
Great project! I needed to upgrade webpack to v2 in order to get some imports working. I have not included package.json in this because I added a bunch of other stuff but the webpack entry is "webpack": "2".

Caveat, I don't know everything the previous config was trying to do but I left it as is and followed migration steps.

P.S. There is a deprecation warning that I have not addressed:

`node:59682) DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56
parseQuery() will be replaced with getOptions() in the next major version of loader-utils.`